### PR TITLE
Retry query on MySQL reconnect bugfix, omit printing stack-trace

### DIFF
--- a/dhcpy6/Storage.py
+++ b/dhcpy6/Storage.py
@@ -694,24 +694,21 @@ class MySQL(Store):
         except:
             import traceback
             traceback.print_exc(file=sys.stdout)
-            return None
+            self.connected = False
+        return self.connected
         
         
     def DBQuery(self, query):
         try:
             self.cursor.execute(query)
-            self.connected = True
-        except:            
-            import traceback
-            traceback.print_exc(file=sys.stdout)
+        except Exception as e:
             # try to reestablish database connection
+            print 'Error: {}'.format(str(e))
             if not self.DBConnect():
-                self.connected = False
                 return None
             else:
                 try:
                     self.cursor.execute(query)
-                    self.connected = True
                 except:
                     import traceback
                     traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
There is a small bug in MySQL class, DBQuery method. If first attempt to query MySQL server fails, then connection to DB is restored but the query is never retired because "if not self.DBConnect():" is always false. The code to retry query is never executed and "None" is returned as result which in turn triggers more exceptions.

I stumbled upon this bug with a MySQL server which have a very short timeout on inactive connections.

This patch prints stack trace only if second attempt to query DB fails. First attempt only dumps exception message.