### PR TITLE
Add autocommit to mysql databases. 

### DIFF
--- a/dhcpy6/Storage.py
+++ b/dhcpy6/Storage.py
@@ -701,6 +701,7 @@ class DB(Store):
                                                    db=self.cfg.STORE_DB_DB,\
                                                    user=self.cfg.STORE_DB_USER,\
                                                    passwd=self.cfg.STORE_DB_PASSWORD)
+                self.connection.autocommit(True)
                 self.cursor = self.connection.cursor()
                 self.connected = True
             except:


### PR DESCRIPTION
I was trying out dhcpy6d and noticed that the leases table wasn't being updated.  A mysql select was returning nothing.  Looking at the code, I realized that I was using an InnoDB table, which either requires autocommit to be turned on or a commit statement after each set of SQL statements we want run.

I've gone for the easy solution.