### PR TITLE
Flush stdout after printing traceback.  

### DIFF
--- a/dhcpy6/Storage.py
+++ b/dhcpy6/Storage.py
@@ -52,6 +52,7 @@ class QueryQueue(threading.Thread):
             except:
                 import traceback
                 traceback.print_exc(file=sys.stdout)
+                sys.stdout.flush()
                 answer = ""
 
             self.answerqueue.put(answer)
@@ -452,6 +453,7 @@ class Store(object):
                     print err
                     import traceback
                     traceback.print_exc(file=sys.stdout)
+                    sys.stdout.flush()
                     return None
                 
         
@@ -477,6 +479,7 @@ class SQLite(Store):
         except:
             import traceback
             traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
 
         
     def DBConnect(self, storage_type="volatile"):
@@ -498,6 +501,7 @@ class SQLite(Store):
         except:
             import traceback
             traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
             return None
         
         
@@ -707,6 +711,7 @@ class DB(Store):
             except:
                 import traceback
                 traceback.print_exc(file=sys.stdout)
+                sys.stdout.flush()
                 self.connected = False
 
         elif self.cfg.STORE_CONFIG == 'postgresql' or self.cfg.STORE_VOLATILE == 'postgresql':
@@ -715,6 +720,7 @@ class DB(Store):
             except:
                 import traceback
                 traceback.print_exc(file=sys.stdout)
+                sys.stdout.flush()
                 ErrorExit('ERROR: Cannot find module psycopg2. Please install to proceed.')
             try:
                 self.connection = psycopg2.connect(host=self.cfg.STORE_DB_HOST,\
@@ -726,6 +732,7 @@ class DB(Store):
             except:
                 import traceback
                 traceback.print_exc(file=sys.stdout)
+                sys.stdout.flush()
                 self.connected = False
         return self.connected
         
@@ -744,6 +751,7 @@ class DB(Store):
                 except:
                     import traceback
                     traceback.print_exc(file=sys.stdout)
+                    sys.stdout.flush()
                     self.connected = False
                     return None
                 

--- a/dhcpy6/Storage.py
+++ b/dhcpy6/Storage.py
@@ -26,6 +26,7 @@ from Helpers import *
 import os
 import pwd
 import grp
+import traceback
 
 
 class QueryQueue(threading.Thread):
@@ -50,7 +51,6 @@ class QueryQueue(threading.Thread):
             try:
                 answer = self.store.DBQuery(query)
             except:
-                import traceback
                 traceback.print_exc(file=sys.stdout)
                 sys.stdout.flush()
                 answer = ""
@@ -451,7 +451,6 @@ class Store(object):
                 except Exception, err:
                     #Log("ERROR: CollectMACsFromDB(): " + str(err))
                     print err
-                    import traceback
                     traceback.print_exc(file=sys.stdout)
                     sys.stdout.flush()
                     return None
@@ -477,7 +476,6 @@ class SQLite(Store):
         try:
             self.DBConnect(storage_type)
         except:
-            import traceback
             traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
 
@@ -499,7 +497,6 @@ class SQLite(Store):
             self.cursor = self.connection.cursor()
             self.connected = True                       
         except:
-            import traceback
             traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             return None
@@ -687,7 +684,6 @@ class DB(Store):
         try:
             self.DBConnect()
         except:
-            ###import traceback
             ###traceback.print_exc(file=sys.stdout)
             pass
         
@@ -709,7 +705,6 @@ class DB(Store):
                 self.cursor = self.connection.cursor()
                 self.connected = True
             except:
-                import traceback
                 traceback.print_exc(file=sys.stdout)
                 sys.stdout.flush()
                 self.connected = False
@@ -718,7 +713,6 @@ class DB(Store):
             try:
                 import psycopg2
             except:
-                import traceback
                 traceback.print_exc(file=sys.stdout)
                 sys.stdout.flush()
                 ErrorExit('ERROR: Cannot find module psycopg2. Please install to proceed.')
@@ -730,7 +724,6 @@ class DB(Store):
                 self.cursor = self.connection.cursor()
                 self.connected = True
             except:
-                import traceback
                 traceback.print_exc(file=sys.stdout)
                 sys.stdout.flush()
                 self.connected = False
@@ -749,7 +742,6 @@ class DB(Store):
                 try:
                     self.cursor.execute(query)
                 except:
-                    import traceback
                     traceback.print_exc(file=sys.stdout)
                     sys.stdout.flush()
                     self.connected = False

--- a/dhcpy6d
+++ b/dhcpy6d
@@ -525,6 +525,7 @@ def BuildClient(transaction_id):
     except Exception,err:
         import traceback
         traceback.print_exc(file=sys.stdout)
+        sys.stdout.flush()
         log.error("BuildClient(): " + str(err))
         return None
 

--- a/dhcpy6d
+++ b/dhcpy6d
@@ -523,7 +523,6 @@ def BuildClient(transaction_id):
         return client
 
     except Exception,err:
-        import traceback
         traceback.print_exc(file=sys.stdout)
         sys.stdout.flush()
         log.error("BuildClient(): " + str(err))
@@ -664,8 +663,8 @@ def CollectMACs():
                             log.info("Collected MAC %s for LinkLocalIP %s" % (f[NC[OS]["mac"]], ColonifyIP6(f[NC[OS]["llip"]])))
                         volatilestore.store_mac_llip(f[NC[OS]["mac"]], f[NC[OS]["llip"]])
     except Exception,err:
-        import traceback
         traceback.print_exc(file=sys.stdout)
+        sys.stdout.flush()
         log.error("CollectMACs(): " + str(err))
 
 
@@ -779,8 +778,8 @@ class DNSQueryThread(threading.Thread):
                     update_rev.delete(dns.reversename.from_address(address), "PTR")  
                 dns.query.tcp(update_rev, cfg.DNS_UPDATE_NAMESERVER)
             except Exception,err:
-                import traceback
                 traceback.print_exc(file=sys.stdout)
+                sys.stdout.flush()
                 log.error("DNSUPDATE: " + str(err))
 
 
@@ -808,8 +807,8 @@ class TidyUpThread(threading.Thread):
                             Transactions.pop(Transactions[t].ID)
                     except Exception, err:
                         log.error("TidyUp: TransactionID %s has already been deleted" % (str(err)))
-                        import traceback
                         traceback.print_exc(file=sys.stdout)
+                        sys.stdout.flush()
                 
                 # if disconnected try reconnect
                 if not volatilestore.connected:
@@ -837,8 +836,8 @@ class TidyUpThread(threading.Thread):
 
                 time.sleep(cfg.CLEANING_INTERVAL)
         except:
-            import traceback
             traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
 
 
 class Client(object):
@@ -1301,8 +1300,8 @@ class Handler(SocketServer.DatagramRequestHandler):
                     Transactions[transaction_id].Counter += 1
 
         except Exception,err:
-            import traceback
             traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
             log.error("handle(): %s | Caused by: %s | Transaction: %s" % (str(err), self.client_address[0], transaction_id))
             return None
 
@@ -1659,8 +1658,8 @@ class Handler(SocketServer.DatagramRequestHandler):
             self.response = binascii.a2b_hex(response_ascii)
             
         except Exception, err:
-            import traceback
             traceback.print_exc(file=sys.stdout)
+            sys.stdout.flush()
             log.error("Response(): " + str(err))
             print transaction_id
             print Transactions[transaction_id].Client.__dict__


### PR DESCRIPTION
This ensures that we see it if stdout is getting redirected to a log.  I'm using systemd's journal and was missing some log messages without this.