### PR TITLE
Only Listify address if address is not already a list

### DIFF
--- a/dhcpy6/Storage.py
+++ b/dhcpy6/Storage.py
@@ -650,7 +650,10 @@ class ClientConfig(object):
         # fixed addresses
         if address:
             self.ADDRESS = list()
-            addresses = ListifyOption(address)
+            if type(address) == list:
+                addresses = address
+            else:
+                addresses = ListifyOption(address)
             for a in addresses:
                 self.ADDRESS.append(DecompressIP6(a))
         else:


### PR DESCRIPTION
For some reason, address is already a list when we get here (possibly because I'm using a MySQL database?).  I'm not sure why it's happening, but just setting addresses to the list if address is a list fixes the problem.  This has been tested when more than one address has been specified, and the addresses are properly split up.


