### PR TITLE
Add EUI-64 address pattern

### DIFF
--- a/dhcpy6/config.py
+++ b/dhcpy6/config.py
@@ -844,9 +844,9 @@ class Config(object):
                     error_exit("%s Address type '%s' is not defined." % (msg_prefix, a))
 
                 # test validity of category
-                if not self.ADDRESSES[a].CATEGORY.strip() in ['fixed', 'range', 'random', 'mac', 'id', 'dns']:
+                if not self.ADDRESSES[a].CATEGORY.strip() in ['eui64', 'fixed', 'range', 'random', 'mac', 'id', 'dns']:
                     error_exit(
-                        "%s Category '%s' is invalid. Category must be one of 'fixed', 'range', 'random', 'mac', 'id' and 'dns'." % (
+                        "%s Category '%s' is invalid. Category must be one of 'eui64'. 'fixed', 'range', 'random', 'mac', 'id' and 'dns'." % (
                         msg_prefix, self.ADDRESSES[a].CATEGORY))
 
                 # test validity of pattern - has its own error output

--- a/dhcpy6/helpers.py
+++ b/dhcpy6/helpers.py
@@ -492,4 +492,6 @@ def mac2eui64(mac):
     eui64 = eui64[0:6] + 'fffe' + eui64[6:]
     eui64 = hex(int(eui64[0:2], 16) ^ 2)[2:].zfill(2) + eui64[2:]
 
-    return eui64
+    split_string = lambda x, n: [x[i:i + n] for i in range(0, len(x), n)]
+
+    return ':'.join(split_string(eui64, 4))

--- a/dhcpy6/helpers.py
+++ b/dhcpy6/helpers.py
@@ -20,6 +20,7 @@
 
 import binascii
 import random
+import re
 import sys
 import shlex
 import logging
@@ -481,3 +482,14 @@ def send_control_message(message):
     message = message.strip('"').strip('"')
     socket_control = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
     socket_control.sendto(message, ('::1', 547))
+
+def mac2eui64(mac):
+    '''
+    Convert a MAC address to a EUI64 address
+    '''
+    # http://tools.ietf.org/html/rfc4291#section-2.5.1
+    eui64 = re.sub(r'[.:-]', '', mac).lower()
+    eui64 = eui64[0:6] + 'fffe' + eui64[6:]
+    eui64 = hex(int(eui64[0:2], 16) ^ 2)[2:].zfill(2) + eui64[2:]
+
+    return eui64

--- a/dhcpy6d
+++ b/dhcpy6d
@@ -701,8 +701,8 @@ def parse_pattern_address(address, client_config, transaction_id):
         a = a.replace('$mac$', ':'.join((macraw[0:4], macraw[4:8], macraw[8:12])))
     elif address.CATEGORY == 'eui64':
         # https://tools.ietf.org/html/rfc4291#section-2.5.1
-        macraw = ''.join(Transactions[transaction_id].MAC.split(':'))
-        a = a.replace('$eui64$', mac2eui64(macraw))
+        mac = Transactions[transaction_id].MAC
+        a = a.replace('$eui64$', mac2eui64(mac))
     elif address.CATEGORY in ['fixed', 'dns']:
         # No patterns for fixed address, let's bail
         return None

--- a/dhcpy6d
+++ b/dhcpy6d
@@ -699,6 +699,10 @@ def parse_pattern_address(address, client_config, transaction_id):
     if address.CATEGORY == 'mac':
         macraw = ''.join(Transactions[transaction_id].MAC.split(':'))
         a = a.replace('$mac$', ':'.join((macraw[0:4], macraw[4:8], macraw[8:12])))
+    elif address.CATEGORY == 'eui64':
+        # https://tools.ietf.org/html/rfc4291#section-2.5.1
+        macraw = ''.join(Transactions[transaction_id].MAC.split(':'))
+        a = a.replace('$eui64$', mac2eui64(macraw))
     elif address.CATEGORY in ['fixed', 'dns']:
         # No patterns for fixed address, let's bail
         return None

--- a/doc/dhcpy6d.conf.rst
+++ b/doc/dhcpy6d.conf.rst
@@ -239,6 +239,9 @@ There can be many address definitions which will be used by classes. Every addre
     **mac**
         Uses MAC address from client request as part of address
 
+    **eui64**
+        Also uses MAC address from client as part of address, but converts it to a 64-bit extended unique identifier (EUI-64)
+
     **id**
         Uses ID given to client in configuration file or database as one octet of address, should be in range 0-ffff
 
@@ -265,11 +268,14 @@ There can be many address definitions which will be used by classes. Every addre
 
 **pattern = 2001:db8::$mac$|$id$|$range$|$random$**
 
-**pattern= $prefix$::$mac$|$id$|$range$|$random$**
+**pattern= $prefix$::$mac$|$eui64$|$id$|$range$|$random$**
     Patterns allow to design the addresses according to their category. See examples section below to make it more clear. 
 
     **$mac$**
         The MAC address from the DHCPv6 request's Link Local Address found in the neighbor cache will be inserted instead of the placeholder. It will be stretched over 3 thus octets like 00:11:22:33:44:55 become 0011:2233:4455.
+
+    **$eui64$**
+        The MAC address converted to a 64-bit extended unique identifier (EUI-64) from the DHCPv6 request's Link Local Address found in the neighbor cache will be inserted instead of the placeholder. It will be stretched over 3 thus octets like 00:11:22:33:44:55 become 0011:2233:4455.
 
     **$id$**
         If clients get an ID in client configuration file or in client configuration database this ID will fill one octet. Thus the ID has to be in the range of 0000-ffff.
@@ -946,6 +952,9 @@ The according class of the client simply must not have any address definition an
     |    category = mac
     |    # ULA-type address pattern.
     |    pattern = fd01:db8:dead:bad:beef:$mac$
+    |    # To use the EUI-64 instead of the plain MAC address:
+    |    #category = eui64
+    |    #pattern = fd01:db8:dead:bad:$eui64$
     |
     |    [class_fixed_address]
     |    # just no address definiton here

--- a/man/man5/dhcpy6d.conf.5
+++ b/man/man5/dhcpy6d.conf.5
@@ -261,6 +261,9 @@ Categories play an important role when defining patterns for addresses. An addre
 .B \fBmac\fP
 Uses MAC address from client request as part of address
 .TP
+.B \fBeui64\fP
+Also uses MAC address from client as part of address, but converts it to a 64\-bit extended unique identifier (EUI\-64)
+.TP
 .B \fBid\fP
 Uses ID given to client in configuration file or database as one octet of address, should be in range 0\-ffff
 .TP
@@ -292,12 +295,15 @@ Maximum hex limit of range, highest is ffff.
 \fBpattern = 2001:db8::$mac$|$id$|$range$|$random$\fP
 .INDENT 0.0
 .TP
-.B \fBpattern= $prefix$::$mac$|$id$|$range$|$random$\fP
+.B \fBpattern= $prefix$::$mac$|$eui64$|$id$|$range$|$random$\fP
 Patterns allow to design the addresses according to their category. See examples section below to make it more clear.
 .INDENT 7.0
 .TP
 .B \fB$mac$\fP
 The MAC address from the DHCPv6 request\(aqs Link Local Address found in the neighbor cache will be inserted instead of the placeholder. It will be stretched over 3 thus octets like 00:11:22:33:44:55 become 0011:2233:4455.
+.TP
+.B \fB$eui64$\fP
+The MAC address converted to a 64\-bit extended unique identifier (EUI\-64) from the DHCPv6 request\(aqs Link Local Address found in the neighbor cache will be inserted instead of the placeholder. It will be stretched over 3 thus octets like 00:11:22:33:44:55 become 0011:2233:4455.
 .TP
 .B \fB$id$\fP
 If clients get an ID in client configuration file or in client configuration database this ID will fill one octet. Thus the ID has to be in the range of 0000\-ffff.
@@ -1027,6 +1033,9 @@ store_sqlite_volatile = /var/lib/dhcpy6d/volatile.sqlite
 category = mac
 # ULA\-type address pattern.
 pattern = fd01:db8:dead:bad:beef:$mac$
+# To use the EUI\-64 instead of the plain MAC address:
+#category = eui64
+#pattern = fd01:db8:dead:bad:$eui64$
 
 [class_fixed_address]
 # just no address definiton here


### PR DESCRIPTION
This allows to assign an modified EUI-64 calculated from the MAC address (defined in https://tools.ietf.org/html/rfc4291#section-2.5.1) as host part.