### PR TITLE
setup.py: make installation with pip more pythonic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,35 @@ import os
 import os.path
 from setuptools import setup, find_packages
 import shutil
+import sys
 
-# workaround to get dhcpy6d-startscript created
-try:
-    if not os.path.exists('sbin'):
-        os.mkdir('sbin')
-    shutil.copyfile('main.py', 'sbin/dhcpy6d')
-    os.chmod('sbin/dhcpy6d', 0o554)
-except:
-    print('could not copy main.py to sbin/dhcpy6d')
+package_data = {'dhcpy6d': ['var/lib/volatile.sqlite',
+                            'var/log/dhcpy6d.log',
+                            'doc/LICENSE', 'doc/*.conf', 'doc/*.sql', 'doc/*.postgresql',
+                            'man/man5/*.conf.5',
+                            'man/man8/*.8',
+                            'etc/*.conf']}
+extra_args = {}
+
+if __name__ == "__main__" and "sdist" in sys.argv:
+    # Workaround to get dhcpy6d-startscript created
+    try:
+        script_name = 'sbin/dhcpy6d'
+        if not os.path.exists('sbin'):
+            os.mkdir('sbin')
+        shutil.copyfile('main.py', script_name)
+        os.chmod(script_name, 0o554)
+        package_data['dhcpy6d'].append(script_name)
+    except:
+        print('could not copy main.py to sbin/dhcpy6d')
+else:
+    extra_args = {
+        "entry_points": {
+            'console_scripts': [
+                'dhcpy6d=main:run'
+            ]
+        },
+    }
 
 classifiers = [
     'Intended Audience :: System Administrators',
@@ -46,22 +66,6 @@ classifiers = [
     'Topic :: System :: Networking'
 ]
 
-data_files = [('/var/lib/dhcpy6d', ['var/lib/volatile.sqlite']),
-              ('/var/log', ['var/log/dhcpy6d.log']),
-              ('/usr/share/doc/dhcpy6d', ['doc/clients-example.conf',
-                                                 'doc/config.sql',
-                                                 'doc/dhcpy6d-example.conf',
-                                                 'doc/dhcpy6d-minimal.conf',
-                                                 'doc/LICENSE',
-                                                 'doc/volatile.sql',
-                                                 'doc/volatile.postgresql']),
-              ('/usr/share/man/man5', ['man/man5/dhcpy6d.conf.5',
-                                              'man/man5/dhcpy6d-clients.conf.5']),
-              ('/usr/share/man/man8', ['man/man8/dhcpy6d.8']),
-              ('/etc', ['etc/dhcpy6d.conf']),
-              ('/usr/sbin', ['sbin/dhcpy6d']),
-              ]
-
 setup(name='dhcpy6d',
       version='1.0.2',
       license='GNU GPL v2',
@@ -71,8 +75,10 @@ setup(name='dhcpy6d',
       author_email='h.wahl@ifw-dresden.de',
       url='https://dhcpy6d.ifw-dresden.de/',
       download_url='https://dhcpy6d.ifw-dresden.de/download',
-      requires=['distro', 'dnspython'],
+      install_requires=['distro', 'dnspython'],
       packages=find_packages(),
+      py_modules=["main"],
       classifiers=classifiers,
-      data_files=data_files
+      package_data=package_data,
+      **extra_args
       )


### PR DESCRIPTION
This allows for dhcpy6d to be installed as user or within a virtualenv without creating foreign files in the users or virtualenv's library directory.

I tested the process with for installing

<details><summary>to a virtualenv and</summary>

```console
$ virtualenv -p python3 env
created virtual environment CPython3.8.6.final.0-64 in 258ms
  creator CPython3Posix(dest=/home/mlenders/Repositories/RIOT-OS/dhcpy6d/env, clear=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/mlenders/.local/share/virtualenv)
    added seed packages: dhcpy6d==1.0.2, distro==1.5.0, dnspython==2.0.0, pip==20.2.4, setuptools==50.3.2, wheel==0.35.1
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
$ . env/bin/activate
0
0
$ pip install .
Processing /home/mlenders/Repositories/RIOT-OS/dhcpy6d
Requirement already satisfied: distro in ./env/lib/python3.8/site-packages (from dhcpy6d==1.0.2) (1.5.0)
Requirement already satisfied: dnspython in ./env/lib/python3.8/site-packages (from dhcpy6d==1.0.2) (2.0.0)
Building wheels for collected packages: dhcpy6d
  Building wheel for dhcpy6d (setup.py) ... done
  Created wheel for dhcpy6d: filename=dhcpy6d-1.0.2-py3-none-any.whl size=115236 sha256=814b5d3b1f787a60e85a8f90bd97ac3d0cf5a26683fd7ed895684cba0e6af2b8
  Stored in directory: /tmp/pip-ephem-wheel-cache-mafzqe1v/wheels/e3/85/10/8615455059a4cca7116f80180e75455e69492f2ad57a1a24f7
Successfully built dhcpy6d
Installing collected packages: dhcpy6d
  Attempting uninstall: dhcpy6d
    Found existing installation: dhcpy6d 1.0.2
    Uninstalling dhcpy6d-1.0.2:
      Successfully uninstalled dhcpy6d-1.0.2
Successfully installed dhcpy6d-1.0.2
$ dhcpy6d --help
option --help not recognized

dhcpy6d - DHCPv6 server

Usage: dhcpy6d --config <file> [--user <user>] [--group <group>] [--duid <duid>] [--prefix <prefix>] [--really-do-it <yes>|<no>]

       dhcpy6d --message '<message>'

       dhcpy6d --generate-duid

See manpage dhcpy6d(8) for details.

```

</details>
<details><summary>on Debian.</summary>

```
$ uname -a
Linux buster 4.19.0-12-amd64 #1 SMP Debian 4.19.152-1 (2020-10-18) x86_64 GNU/Linux
$ ./build.sh
[…]
$ sudo apt-get install python3-distro python3-dnspython
[…]
$ sudo dpkg -i ../dhcpy6d_1.0.2-1_all.deb
[…]
$ ls /usr/sbin/dhcpy6d 
/usr/sbin/dhcpy6d
$ sudo ls /var/lib/dhcpy6d/
volatile.sqlite
[...]
```
</details>

I also tried on CentOS 7, and the build was successful, but I was unable to install the RPM, due to missing dependencies:

```
[vagrant@localhost dhcpy6d]$ sudo rpm -i ../dhcpy6d.1839/RPMS/noarch/dhcpy6d-1.0.2-1.el7.noarch.rpm 
error: Failed dependencies:
	python3-PyMySQL is needed by dhcpy6d-1.0.2-1.el7.noarch
	python3-distro is needed by dhcpy6d-1.0.2-1.el7.noarch
	python3-dns is needed by dhcpy6d-1.0.2-1.el7.noarch
[vagrant@localhost dhcpy6d]$ sudo yum install python3-PyMySQL python3-distro python3-dns
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: centos.schlundtech.de
 * extras: mirror.23media.com
 * updates: ftp.fau.de
No package python3-PyMySQL available.
No package python3-distro available.
No package python3-dns available.
Error: Nothing to do
```

(I am not a regular CentOS user, so I might have done something wrong)