### PR TITLE
Fix typos and grammar issues reported by Debian's Lintian tool

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -41,7 +41,7 @@ Changelog for dhcpy6d
 
     added ntp_server option
     added request limits
-    allow to inject prefix - e.g. changed prefix from ISP
+    allow one to inject prefix - e.g. changed prefix from ISP
     optimized time requests
     ignore unknown clients
     fixes for prefix delegation

--- a/debian/changelog
+++ b/debian/changelog
@@ -61,7 +61,7 @@ dhcpy6d (0.7-1) stable; urgency=medium
   * New upstream release
     + added ntp_server option
     + added request limits
-    + allow to inject prefix - e.g. changed prefix from ISP
+    + allow one to inject prefix - e.g. changed prefix from ISP
     + optimized time requests
     + ignore unknown clients
     + fixes for prefix delegation

--- a/dhcpy6d/config.py
+++ b/dhcpy6d/config.py
@@ -192,7 +192,7 @@ class Config:
         self.IDENTIFICATION = 'mac'
         self.IDENTIFICATION_MODE = 'match_all'
 
-        # allow to ignore IAIDs which play no big role at all for server
+        # allow one to ignore IAIDs which play no big role at all for server
         self.IGNORE_IAID = 'False'
 
         # ignore clients which do no appear in the neighbor cache table

--- a/doc/dhcpy6d.conf.rst
+++ b/doc/dhcpy6d.conf.rst
@@ -39,7 +39,7 @@ There are 5 types of sections:
     Prefixes are organized in classes. For details read further down.
 
 **[class_<class_name>]**
-    Class definitions allow to apply different addresses, time limits et al. to different types of clients.
+    Class definitions allow one to apply different addresses, time limits et al. to different types of clients.
 
 **[bootfile_<bootfile_name>]**
     There can be various *[bootfile_<bootfile_name>]* sections. In several bootfile sections several tftp bootfile urls with restrictions
@@ -274,7 +274,7 @@ There can be many address definitions which will be used by classes. Every addre
 **pattern = 2001:db8::$mac$|$id$|$range$|$random$**
 
 **pattern= $prefix$::$mac$|$eui64$|$id$|$range$|$random$**
-    Patterns allow to design the addresses according to their category. See examples section below to make it more clear. 
+    Patterns allow one to design the addresses according to their category. See examples section below to make it more clear. 
 
     **$mac$**
         The MAC address from the DHCPv6 request's Link Local Address found in the neighbor cache will be inserted instead of the placeholder. It will be stretched over 3 thus octets like 00:11:22:33:44:55 become 0011:2233:4455.
@@ -342,7 +342,7 @@ A prefix definition may contain several properties:
 **pattern = 2001:db8:$range$::**
 
 **pattern= $prefix$:$range$::**
-    Patterns allow to design the addresses according to their category. See examples section below to make it more clear.
+    Patterns allow one to design the addresses according to their category. See examples section below to make it more clear.
 
     **$range$**
         If address is of category range the range defined with extra keyword *range* will be used here in place of one octet.
@@ -395,14 +395,14 @@ A client gets the addresses, nameserver and T1/T2 values of the class which it i
 **filter_mac = <regular_expression>**
 
 **filter_duid = <regular_expression>**
-    Filters allow to apply a class to a client not by configuration but by a matching regular expression filter. Most useful might be the filtering by hostname, but maybe there is some use for DUID and MAC address based filtering too.
+    Filters allow one to apply a class to a client not by configuration but by a matching regular expression filter. Most useful might be the filtering by hostname, but maybe there is some use for DUID and MAC address based filtering too.
     The regular expressions are meant to by Python Regular Expressions. See `<https://docs.python.org/2/howto/regex.html>`_ and examples section below for details.
 
 **interface = <interface> [<interface> ...]**
     It is possible to let a class only apply on specific interfaces. These have to be separated by spaces.
 
 **advertise = addresses|prefixes**
-    A class per default allows to advertise addresses as well as prefixes if requested. This option allows to narrow the answers down to either *addresses* or *prefixes*.
+    A class per default allows one to advertise addresses as well as prefixes if requested. This option allows to narrow the answers down to either *addresses* or *prefixes*.
     *Default: addresses*
 
 **call_up = <executable> [$prefix$] [$length$] [$router$]**

--- a/doc/dhcpy6d.conf.rst
+++ b/doc/dhcpy6d.conf.rst
@@ -42,7 +42,7 @@ There are 5 types of sections:
     Class definitions allow to apply different addresses, time limits et al. to different types of clients.
 
 **[bootfile_<bootfile_name>]**
-    There can be various *[bootfile_<bootfile_name>]* sections. In serveral bootfile sections several tftp bootfile urls with restrictions
+    There can be various *[bootfile_<bootfile_name>]* sections. In several bootfile sections several tftp bootfile urls with restrictions
     to CPU architecture and user class supplied by the PXE client can be defined.
 
 
@@ -209,7 +209,7 @@ environments.
     *Default: yes*
 
 **request_limit = yes|no**
-    Enables request limits for clients wich can be controled by *request_limit_time* and *request_limit_count*.
+    Enables request limits for clients wich can be controlled by *request_limit_time* and *request_limit_count*.
     *Default: no*
 
 **request_limit_identification = mac|llip**
@@ -376,7 +376,7 @@ A client gets the addresses, nameserver and T1/T2 values of the class which it i
     If a class does not contain any addresses clients won't get any address except they have one fixed defined in client configuration file or database.
 
 **prefixes = <prefix_name> [<address_name> ...]**
-    A class can contain prefixes - even most probably only one prefix will be usefull. *Name* means the *name*-part of a prefiy section.
+    A class can contain prefixes - even most probably only one prefix will be useful. *Name* means the *name*-part of a prefiy section.
 
 **answer = normal|noaddress|none**
     Normally a client will get an answer, but if for whatever reason is a need to give it an *NoAddrAvail* message back or completely ignore the client it can be set here.
@@ -942,7 +942,7 @@ Here dhcpy6d also provides prefixes in the default class. To avoid heavy load by
     |    ignore_iaid = yes
     |    ignore_unknown_clients = yes
     |
-    |    advertise = adresses prefixes
+    |    advertise = addresses prefixes
     |    manage_routes_at_start = yes
     |
     |    [address_default]

--- a/doc/dhcpy6d.rst
+++ b/doc/dhcpy6d.rst
@@ -63,7 +63,7 @@ Most configuration is done via the configuration file.
     Really activate the DHCPv6 server. This is a precaution to prevent larger network trouble.
 
 **-d, --duid=<duid>**
-    Set the DUID for the server. This argument is used by /etc/init.d/dhcpy6d and /lib/systemd/system/dhcpy6d.service repectively.
+    Set the DUID for the server. This argument is used by /etc/init.d/dhcpy6d and /lib/systemd/system/dhcpy6d.service respectively.
 
 **-p, --prefix=<prefix>**
     Set the prefix which will be substituted for the $prefix$ variable in address definitions. Useful for setups where the ISP uses a changing prefix.

--- a/man/man5/dhcpy6d.conf.5
+++ b/man/man5/dhcpy6d.conf.5
@@ -57,7 +57,7 @@ There can be various \fI[prefix_<prefix_name>]\fP sections. In several prefix se
 Prefixes are organized in classes. For details read further down.
 .TP
 .B \fB[class_<class_name>]\fP
-Class definitions allow to apply different addresses, time limits et al. to different types of clients.
+Class definitions allow one to apply different addresses, time limits et al. to different types of clients.
 .TP
 .B \fB[bootfile_<bootfile_name>]\fP
 There can be various \fI[bootfile_<bootfile_name>]\fP sections. In several bootfile sections several tftp bootfile urls with restrictions
@@ -297,7 +297,7 @@ Maximum hex limit of range, highest is ffff.
 .INDENT 0.0
 .TP
 .B \fBpattern= $prefix$::$mac$|$eui64$|$id$|$range$|$random$\fP
-Patterns allow to design the addresses according to their category. See examples section below to make it more clear.
+Patterns allow one to design the addresses according to their category. See examples section below to make it more clear.
 .INDENT 7.0
 .TP
 .B \fB$mac$\fP
@@ -374,7 +374,7 @@ Maximum hex limit of range, highest is ffff.
 .INDENT 0.0
 .TP
 .B \fBpattern= $prefix$:$range$::\fP
-Patterns allow to design the addresses according to their category. See examples section below to make it more clear.
+Patterns allow one to design the addresses according to their category. See examples section below to make it more clear.
 .INDENT 7.0
 .TP
 .B \fB$range$\fP
@@ -434,14 +434,14 @@ Each class can have its own \fBt1\fP and \fBt2\fP values. The ones from general 
 .INDENT 0.0
 .TP
 .B \fBfilter_duid = <regular_expression>\fP
-Filters allow to apply a class to a client not by configuration but by a matching regular expression filter. Most useful might be the filtering by hostname, but maybe there is some use for DUID and MAC address based filtering too.
+Filters allow one to apply a class to a client not by configuration but by a matching regular expression filter. Most useful might be the filtering by hostname, but maybe there is some use for DUID and MAC address based filtering too.
 The regular expressions are meant to by Python Regular Expressions. See \fI\%https://docs.python.org/2/howto/regex.html\fP and examples section below for details.
 .TP
 .B \fBinterface = <interface> [<interface> ...]\fP
 It is possible to let a class only apply on specific interfaces. These have to be separated by spaces.
 .TP
 .B \fBadvertise = addresses|prefixes\fP
-A class per default allows to advertise addresses as well as prefixes if requested. This option allows to narrow the answers down to either \fIaddresses\fP or \fIprefixes\fP\&.
+A class per default allows one to advertise addresses as well as prefixes if requested. This option allows to narrow the answers down to either \fIaddresses\fP or \fIprefixes\fP\&.
 \fIDefault: addresses\fP
 .TP
 .B \fBcall_up = <executable> [$prefix$] [$length$] [$router$]\fP

--- a/man/man5/dhcpy6d.conf.5
+++ b/man/man5/dhcpy6d.conf.5
@@ -60,7 +60,7 @@ Prefixes are organized in classes. For details read further down.
 Class definitions allow to apply different addresses, time limits et al. to different types of clients.
 .TP
 .B \fB[bootfile_<bootfile_name>]\fP
-There can be various \fI[bootfile_<bootfile_name>]\fP sections. In serveral bootfile sections several tftp bootfile urls with restrictions
+There can be various \fI[bootfile_<bootfile_name>]\fP sections. In several bootfile sections several tftp bootfile urls with restrictions
 to CPU architecture and user class supplied by the PXE client can be defined.
 .UNINDENT
 .SH GENERAL CONFIGURATION IN SECTION [DHCPY6D]
@@ -227,7 +227,7 @@ Ignore clients if no trace of them can be found in the neighbor cache.
 \fIDefault: yes\fP
 .TP
 .B \fBrequest_limit = yes|no\fP
-Enables request limits for clients wich can be controled by \fIrequest_limit_time\fP and \fIrequest_limit_count\fP\&.
+Enables request limits for clients wich can be controlled by \fIrequest_limit_time\fP and \fIrequest_limit_count\fP\&.
 \fIDefault: no\fP
 .TP
 .B \fBrequest_limit_identification = mac|llip\fP
@@ -411,7 +411,7 @@ A class can contain as many addresses as needed. Their names have to be separate
 If a class does not contain any addresses clients won\(aqt get any address except they have one fixed defined in client configuration file or database.
 .TP
 .B \fBprefixes = <prefix_name> [<address_name> ...]\fP
-A class can contain prefixes \- even most probably only one prefix will be usefull. \fIName\fP means the \fIname\fP\-part of a prefiy section.
+A class can contain prefixes \- even most probably only one prefix will be useful. \fIName\fP means the \fIname\fP\-part of a prefiy section.
 .TP
 .B \fBanswer = normal|noaddress|none\fP
 Normally a client will get an answer, but if for whatever reason is a need to give it an \fINoAddrAvail\fP message back or completely ignore the client it can be set here.
@@ -1024,7 +1024,7 @@ request_limit_identification = llip
 ignore_iaid = yes
 ignore_unknown_clients = yes
 
-advertise = adresses prefixes
+advertise = addresses prefixes
 manage_routes_at_start = yes
 
 [address_default]

--- a/man/man8/dhcpy6d.8
+++ b/man/man8/dhcpy6d.8
@@ -87,7 +87,7 @@ Set the unprivileged group to be used.
 Really activate the DHCPv6 server. This is a precaution to prevent larger network trouble.
 .TP
 .B \fB\-d, \-\-duid=<duid>\fP
-Set the DUID for the server. This argument is used by /etc/init.d/dhcpy6d and /lib/systemd/system/dhcpy6d.service repectively.
+Set the DUID for the server. This argument is used by /etc/init.d/dhcpy6d and /lib/systemd/system/dhcpy6d.service respectively.
 .TP
 .B \fB\-p, \-\-prefix=<prefix>\fP
 Set the prefix which will be substituted for the $prefix$ variable in address definitions. Useful for setups where the ISP uses a changing prefix.


### PR DESCRIPTION
The first commit contains obvious and undisputed typos.

The second commit contains grammar fixes which seem to be a bit controversial (if they are real issues and if the changes are actually better). Hence a separate commit which can be omitted if unwanted. The affected sentences might stand to profit from general rephrasing.

Some of the changed lines—especially those whose length changed a lot—might need reindenting, too.
