### PR TITLE
Fix two more typos found by Debian's Lintian tool

### DIFF
--- a/doc/dhcpy6d.conf.rst
+++ b/doc/dhcpy6d.conf.rst
@@ -209,7 +209,7 @@ environments.
     *Default: yes*
 
 **request_limit = yes|no**
-    Enables request limits for clients wich can be controlled by *request_limit_time* and *request_limit_count*.
+    Enables request limits for clients which can be controlled by *request_limit_time* and *request_limit_count*.
     *Default: no*
 
 **request_limit_identification = mac|llip**
@@ -402,7 +402,7 @@ A client gets the addresses, nameserver and T1/T2 values of the class which it i
     It is possible to let a class only apply on specific interfaces. These have to be separated by spaces.
 
 **advertise = addresses|prefixes**
-    A class per default allows one to advertise addresses as well as prefixes if requested. This option allows to narrow the answers down to either *addresses* or *prefixes*.
+    A class per default allows one to advertise addresses as well as prefixes if requested. This option allows one to narrow the answers down to either *addresses* or *prefixes*.
     *Default: addresses*
 
 **call_up = <executable> [$prefix$] [$length$] [$router$]**

--- a/man/man5/dhcpy6d.conf.5
+++ b/man/man5/dhcpy6d.conf.5
@@ -227,7 +227,7 @@ Ignore clients if no trace of them can be found in the neighbor cache.
 \fIDefault: yes\fP
 .TP
 .B \fBrequest_limit = yes|no\fP
-Enables request limits for clients wich can be controlled by \fIrequest_limit_time\fP and \fIrequest_limit_count\fP\&.
+Enables request limits for clients which can be controlled by \fIrequest_limit_time\fP and \fIrequest_limit_count\fP\&.
 \fIDefault: no\fP
 .TP
 .B \fBrequest_limit_identification = mac|llip\fP
@@ -441,7 +441,7 @@ The regular expressions are meant to by Python Regular Expressions. See \fI\%htt
 It is possible to let a class only apply on specific interfaces. These have to be separated by spaces.
 .TP
 .B \fBadvertise = addresses|prefixes\fP
-A class per default allows one to advertise addresses as well as prefixes if requested. This option allows to narrow the answers down to either \fIaddresses\fP or \fIprefixes\fP\&.
+A class per default allows one to advertise addresses as well as prefixes if requested. This option allows one to narrow the answers down to either \fIaddresses\fP or \fIprefixes\fP\&.
 \fIDefault: addresses\fP
 .TP
 .B \fBcall_up = <executable> [$prefix$] [$length$] [$router$]\fP


### PR DESCRIPTION
Sorry, seem to have overseen these in my previous pull request.