### PR TITLE
Fixed default behavior (route_link_local=no) in clients.conf

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,9 @@
 Changelog for dhcpy6d
 
+2021-03-18 1.0.4
+
+    Fixed default behavior (route_link_local=no) in clients.conf
+
 2020-11-20 1.0.3
 
     added option DNS_USE_RNDC

--- a/dhcpy6d/client/from_config.py
+++ b/dhcpy6d/client/from_config.py
@@ -60,7 +60,7 @@ def from_config(client=None, client_config=None, transaction=None):
                                length=prefix['length'],
                                preferred_lifetime=cfg.PREFERRED_LIFETIME,
                                valid_lifetime=cfg.VALID_LIFETIME,
-                               route_link_local=True)
+                               route_link_local=False)
                 client.prefixes.append(ia_pd)
 
         if not client_config.CLASS == '':


### PR DESCRIPTION
## What?
This PR sets the default behavior to `route_link_local=no`. It affects how call_up and call_down scripts are being run.

The default value of `route_link_local` option is `no` when used in [prefix_<name>] definition. However, for statically configured clients in `client.conf`, default value was `yes` and it's confusing. 

## Why?
It's always reasonable for boolean config options to default to `false` when an option isn't declared.

## Steps to reproduce
Have following in clients.conf:
```
[client1]
hostname = client1
mac = 08:00:27:3e:9b:23
class = valid_client
address = 3001:db8::192:168:200:100
prefix = 3001:db9:1234:5000::/54
```

and dhcpy6d.conf
```
[class_valid_client]
advertise = addresses, prefixes
call_up = ip -6 route add $prefix$/$length$ via $router$ dev enp0s8
call_down = ip -6 route delete $prefix$/$length$ via $router$ dev enp0s8
```

Let the client solicit for the new configuration. See logs.

Before:
```
2021-03-18 15:55:48,022 dhcpy6d INFO Called 'ip -6 route add 3001:0db9:1234:5000:0000:0000:0000:0000/54 via fe80:0000:0000:0000:0a00:27ff:fe3e:9b23 dev enp0s8' to modify route
```
⚠️ The `via` address is link-local. 

After
```
2021-03-18 15:56:00,443 dhcpy6d INFO Called 'ip -6 route add 3001:0db9:1234:5000:0000:0000:0000:0000/54 via 3001:0db8:0000:0000:0192:0168:0200:0100 dev enp0s8' to modify route
```
✅ The `via` address is global.


