### PR TITLE
Fix typos in RFC 3849 documentation range (2001:cb8:: → 2001:db8::)

### DIFF
--- a/doc/dhcpy6d-clients.conf.rst
+++ b/doc/dhcpy6d-clients.conf.rst
@@ -99,7 +99,7 @@ The next lines contain some example client definitions:
 | hostname = client3
 | duid = 000100011234567890abcdef1234
 | class = valid_client
-| address = 2001:cb8::babe:1
+| address = 2001:db8::babe:1
 
 | [client4]
 | hostname = client4
@@ -111,7 +111,7 @@ The next lines contain some example client definitions:
 | hostname = client5
 | mac = 01:01:01:01:01:02
 | class = valid_client
-| prefix = 2001:cb8::/48
+| prefix = 2001:db8::/48
 
 License
 =======

--- a/man/man5/dhcpy6d-clients.conf.5
+++ b/man/man5/dhcpy6d-clients.conf.5
@@ -115,7 +115,7 @@ class = invalid_client
 hostname = client3
 duid = 000100011234567890abcdef1234
 class = valid_client
-address = 2001:cb8::babe:1
+address = 2001:db8::babe:1
 .fi
 .sp
 .nf
@@ -131,7 +131,7 @@ class = valid_client
 hostname = client5
 mac = 01:01:01:01:01:02
 class = valid_client
-prefix = 2001:cb8::/48
+prefix = 2001:db8::/48
 .fi
 .sp
 .SH LICENSE


### PR DESCRIPTION
I at least assume these were (probably later copied and pasted) typos and not on purpose.