### PR TITLE
Added option `prefix_route_link_local` to dhcpy6d-clients.conf

### DIFF
--- a/dhcpy6d/client/from_config.py
+++ b/dhcpy6d/client/from_config.py
@@ -60,7 +60,7 @@ def from_config(client=None, client_config=None, transaction=None):
                                length=prefix['length'],
                                preferred_lifetime=cfg.PREFERRED_LIFETIME,
                                valid_lifetime=cfg.VALID_LIFETIME,
-                               route_link_local=False)
+                               route_link_local=client_config.PREFIX_ROUTE_LINK_LOCAL)
                 client.prefixes.append(ia_pd)
 
         if not client_config.CLASS == '':

--- a/dhcpy6d/config.py
+++ b/dhcpy6d/config.py
@@ -124,6 +124,9 @@ class Config:
         # config type
         # one of file, mysql, sqlite or none
         self.STORE_CONFIG = 'none'
+        # config schema version
+        self.STORE_CONFIG_SCHEMA_VERSION = 1
+
         # one of mysql, postgresql or sqlite
         self.STORE_VOLATILE = 'sqlite'
 

--- a/dhcpy6d/storage/__init__.py
+++ b/dhcpy6d/storage/__init__.py
@@ -29,6 +29,7 @@ from ..globals import (config_answer_queue,
                        volatile_store)
 from ..helpers import error_exit
 
+from .store_schema import StoreSchema
 from .mysql import DBMySQL
 from .postgresql import DBPostgreSQL
 from .sqlite import SQLite
@@ -71,6 +72,8 @@ class QueryQueue(threading.Thread):
 # source of configuration of hosts
 # use client configuration only if needed
 if cfg.STORE_CONFIG:
+    StoreSchema.set_version(cfg.STORE_CONFIG_SCHEMA_VERSION)
+
     if cfg.STORE_CONFIG == 'file':
         config_store = Textfile(config_query_queue, config_answer_queue)
     if cfg.STORE_CONFIG == 'mysql':

--- a/dhcpy6d/storage/store_schema.py
+++ b/dhcpy6d/storage/store_schema.py
@@ -1,0 +1,39 @@
+# DHCPy6d DHCPv6 Daemon
+#
+# Copyright (C) 2009-2021 Henri Wahl <henri@dhcpy6d.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+class StoreSchema:
+    supported_versions = [1, 2]
+
+    version = 1
+
+    @staticmethod
+    def set_version(version):
+        if version not in StoreSchema.supported_versions:
+            raise Exception('Unsupported store schema version %d.' % version)
+
+        StoreSchema.version = version
+
+    @staticmethod
+    def get_host_table_fields():
+        # The elements in fields will be passed unquoted to SQL queries, NEVER use any user input here!
+        fields = ['hostname', 'mac', 'duid', 'class', 'address', 'prefix', 'id']
+
+        if StoreSchema.version >= 2:
+            fields += ['prefix_route_link_local']
+
+        return fields

--- a/doc/config.sql
+++ b/doc/config.sql
@@ -4,6 +4,7 @@ CREATE TABLE hosts (
   class varchar(255) DEFAULT NULL,
   address varchar(255) DEFAULT NULL,
   prefix varchar(255) DEFAULT NULL,
+  prefix_route_link_local INT DEFAULT 0,
   id varchar(255) DEFAULT NULL,
   duid varchar(255) DEFAULT NULL,
   PRIMARY KEY (hostname)


### PR DESCRIPTION
This is a follow-up to #38 and #39. This changed the default behavior of calling hooks for `prefix`. It was reasonable, but sometimes you are required explicitly to use the link-local address, e.g. when the client receives more than one address.

To allow everyone to set the required behavior, this adds a `prefix_route_link_local` in `dhcpy6d-clients.conf`.

TODO:
* Update doc
* Test changes! (therefore a draft yet)
* @HenriWahl What about changes to configuration database scheme? Is that fine, or should we avoid that?