### PR TITLE
Fix indentation issue in option 23

### DIFF
--- a/dhcpy6d/options/option_23.py
+++ b/dhcpy6d/options/option_23.py
@@ -41,11 +41,11 @@ class Option(OptionTemplate):
                     nameserver += inet_pton(AF_INET6, ns)
                 response_string_part = self.convert_to_string(self.number, hexlify(nameserver).decode())
                 options_answer_part = self.number
-        elif len(cfg.NAMESERVER) > 0:
-            # in case several nameservers are given convert them all and add them
-            nameserver = b''
-            for ns in cfg.NAMESERVER:
-                nameserver += inet_pton(AF_INET6, ns)
-            response_string_part = self.convert_to_string(self.number, hexlify(nameserver).decode())
-            options_answer_part = self.number
+            elif len(cfg.NAMESERVER) > 0:
+                # in case several nameservers are given convert them all and add them
+                nameserver = b''
+                for ns in cfg.NAMESERVER:
+                    nameserver += inet_pton(AF_INET6, ns)
+                response_string_part = self.convert_to_string(self.number, hexlify(nameserver).decode())
+                options_answer_part = self.number
         return response_string_part, options_answer_part


### PR DESCRIPTION
Hello,

Option 23 does not seem to be sent to the clients if no ``nameserver`` variable is specified in the clients class even if the global ``nameserver`` variable is set. 

I think it comes from an indentation issue in the code, as the ``elif`` statement is currently put after the ``transaction.client`` check. Indenting the block indeed seems to solve the issue.

Cordially,
Anthony