### PR TITLE
Avoid duplicate fixed DHCPv6 addresses

### DIFF
--- a/dhcpy6d/client/from_config.py
+++ b/dhcpy6d/client/from_config.py
@@ -85,6 +85,7 @@ def from_config(client=None, client_config=None, transaction=None):
 
         if not client_config.CLASS == '':
             # add all addresses which belong to that class
+            configured_addresses = {decompress_ip6(address.ADDRESS) for address in client.addresses}
             for address in cfg.CLASSES[client_config.CLASS].ADDRESSES:
                 # addresses of category 'dns' will be searched in DNS
                 if cfg.ADDRESSES[address].CATEGORY == 'dns':
@@ -92,7 +93,7 @@ def from_config(client=None, client_config=None, transaction=None):
                 else:
                     a = parse_pattern_address(cfg.ADDRESSES[address], client_config, transaction)
                 # in case range has been exceeded a will be None
-                if a:
+                if a and decompress_ip6(a) not in configured_addresses:
                     ia = Address(address=a,
                                  ia_type=cfg.ADDRESSES[address].IA_TYPE,
                                  preferred_lifetime=cfg.ADDRESSES[address].PREFERRED_LIFETIME,
@@ -105,6 +106,7 @@ def from_config(client=None, client_config=None, transaction=None):
                                  dns_rev_zone=cfg.ADDRESSES[address].DNS_REV_ZONE,
                                  dns_ttl=cfg.ADDRESSES[address].DNS_TTL)
                     client.addresses.append(ia)
+                    configured_addresses.add(decompress_ip6(a))
 
             # add all bootfiles which belong to that class
             for bootfile in cfg.CLASSES[client_config.CLASS].BOOTFILES:

--- a/dhcpy6d/client/from_config.py
+++ b/dhcpy6d/client/from_config.py
@@ -84,31 +84,29 @@ def from_config(client=None, client_config=None, transaction=None):
                 client.prefixes.append(ia_pd)
 
         if not client_config.CLASS == '':
-            # A fixed client address list is authoritative.  Adding class
-            # addresses here creates IAADDRs which the client did not request
-            # and makes ISC dhclient discard the subsequent REPLY.
-            if not client.addresses:
-                # add all addresses which belong to that class
-                for address in cfg.CLASSES[client_config.CLASS].ADDRESSES:
-                    # addresses of category 'dns' will be searched in DNS
-                    if cfg.ADDRESSES[address].CATEGORY == 'dns':
-                        a = get_ip_from_dns(client.hostname)
-                    else:
-                        a = parse_pattern_address(cfg.ADDRESSES[address], client_config, transaction)
-                    # in case range has been exceeded a will be None
-                    if a:
-                        ia = Address(address=a,
-                                     ia_type=cfg.ADDRESSES[address].IA_TYPE,
-                                     preferred_lifetime=cfg.ADDRESSES[address].PREFERRED_LIFETIME,
-                                     valid_lifetime=cfg.ADDRESSES[address].VALID_LIFETIME,
-                                     category=cfg.ADDRESSES[address].CATEGORY,
-                                     aclass=cfg.ADDRESSES[address].CLASS,
-                                     atype=cfg.ADDRESSES[address].TYPE,
-                                     dns_update=cfg.ADDRESSES[address].DNS_UPDATE,
-                                     dns_zone=cfg.ADDRESSES[address].DNS_ZONE,
-                                     dns_rev_zone=cfg.ADDRESSES[address].DNS_REV_ZONE,
-                                     dns_ttl=cfg.ADDRESSES[address].DNS_TTL)
-                        client.addresses.append(ia)
+            # add all addresses which belong to that class
+            configured_addresses = {decompress_ip6(address.ADDRESS) for address in client.addresses}
+            for address in cfg.CLASSES[client_config.CLASS].ADDRESSES:
+                # addresses of category 'dns' will be searched in DNS
+                if cfg.ADDRESSES[address].CATEGORY == 'dns':
+                    a = get_ip_from_dns(client.hostname)
+                else:
+                    a = parse_pattern_address(cfg.ADDRESSES[address], client_config, transaction)
+                # in case range has been exceeded a will be None
+                if a and decompress_ip6(a) not in configured_addresses:
+                    ia = Address(address=a,
+                                 ia_type=cfg.ADDRESSES[address].IA_TYPE,
+                                 preferred_lifetime=cfg.ADDRESSES[address].PREFERRED_LIFETIME,
+                                 valid_lifetime=cfg.ADDRESSES[address].VALID_LIFETIME,
+                                 category=cfg.ADDRESSES[address].CATEGORY,
+                                 aclass=cfg.ADDRESSES[address].CLASS,
+                                 atype=cfg.ADDRESSES[address].TYPE,
+                                 dns_update=cfg.ADDRESSES[address].DNS_UPDATE,
+                                 dns_zone=cfg.ADDRESSES[address].DNS_ZONE,
+                                 dns_rev_zone=cfg.ADDRESSES[address].DNS_REV_ZONE,
+                                 dns_ttl=cfg.ADDRESSES[address].DNS_TTL)
+                    client.addresses.append(ia)
+                    configured_addresses.add(decompress_ip6(a))
 
             # add all bootfiles which belong to that class
             for bootfile in cfg.CLASSES[client_config.CLASS].BOOTFILES:

--- a/dhcpy6d/client/from_config.py
+++ b/dhcpy6d/client/from_config.py
@@ -84,29 +84,31 @@ def from_config(client=None, client_config=None, transaction=None):
                 client.prefixes.append(ia_pd)
 
         if not client_config.CLASS == '':
-            # add all addresses which belong to that class
-            configured_addresses = {decompress_ip6(address.ADDRESS) for address in client.addresses}
-            for address in cfg.CLASSES[client_config.CLASS].ADDRESSES:
-                # addresses of category 'dns' will be searched in DNS
-                if cfg.ADDRESSES[address].CATEGORY == 'dns':
-                    a = get_ip_from_dns(client.hostname)
-                else:
-                    a = parse_pattern_address(cfg.ADDRESSES[address], client_config, transaction)
-                # in case range has been exceeded a will be None
-                if a and decompress_ip6(a) not in configured_addresses:
-                    ia = Address(address=a,
-                                 ia_type=cfg.ADDRESSES[address].IA_TYPE,
-                                 preferred_lifetime=cfg.ADDRESSES[address].PREFERRED_LIFETIME,
-                                 valid_lifetime=cfg.ADDRESSES[address].VALID_LIFETIME,
-                                 category=cfg.ADDRESSES[address].CATEGORY,
-                                 aclass=cfg.ADDRESSES[address].CLASS,
-                                 atype=cfg.ADDRESSES[address].TYPE,
-                                 dns_update=cfg.ADDRESSES[address].DNS_UPDATE,
-                                 dns_zone=cfg.ADDRESSES[address].DNS_ZONE,
-                                 dns_rev_zone=cfg.ADDRESSES[address].DNS_REV_ZONE,
-                                 dns_ttl=cfg.ADDRESSES[address].DNS_TTL)
-                    client.addresses.append(ia)
-                    configured_addresses.add(decompress_ip6(a))
+            # A fixed client address list is authoritative.  Adding class
+            # addresses here creates IAADDRs which the client did not request
+            # and makes ISC dhclient discard the subsequent REPLY.
+            if not client.addresses:
+                # add all addresses which belong to that class
+                for address in cfg.CLASSES[client_config.CLASS].ADDRESSES:
+                    # addresses of category 'dns' will be searched in DNS
+                    if cfg.ADDRESSES[address].CATEGORY == 'dns':
+                        a = get_ip_from_dns(client.hostname)
+                    else:
+                        a = parse_pattern_address(cfg.ADDRESSES[address], client_config, transaction)
+                    # in case range has been exceeded a will be None
+                    if a:
+                        ia = Address(address=a,
+                                     ia_type=cfg.ADDRESSES[address].IA_TYPE,
+                                     preferred_lifetime=cfg.ADDRESSES[address].PREFERRED_LIFETIME,
+                                     valid_lifetime=cfg.ADDRESSES[address].VALID_LIFETIME,
+                                     category=cfg.ADDRESSES[address].CATEGORY,
+                                     aclass=cfg.ADDRESSES[address].CLASS,
+                                     atype=cfg.ADDRESSES[address].TYPE,
+                                     dns_update=cfg.ADDRESSES[address].DNS_UPDATE,
+                                     dns_zone=cfg.ADDRESSES[address].DNS_ZONE,
+                                     dns_rev_zone=cfg.ADDRESSES[address].DNS_REV_ZONE,
+                                     dns_ttl=cfg.ADDRESSES[address].DNS_TTL)
+                        client.addresses.append(ia)
 
             # add all bootfiles which belong to that class
             for bootfile in cfg.CLASSES[client_config.CLASS].BOOTFILES:

--- a/dhcpy6d/config.py
+++ b/dhcpy6d/config.py
@@ -846,7 +846,7 @@ class Config:
             error_exit(f"{msg_prefix} Request limit identification must be one of 'mac' or 'llip'.")
 
         # check if cleaning interval is a number
-        if not self.CLEANING_INTERVAL.isdigit():
+        if not str(self.CLEANING_INTERVAL).isdigit():
             error_exit(f"{msg_prefix} Cleaning interval "
                        f"'{self.CLEANING_INTERVAL}' is invalid.")
 

--- a/tests/test_prefix_substitution.py
+++ b/tests/test_prefix_substitution.py
@@ -165,7 +165,7 @@ class PrefixSubstitutionTest(unittest.TestCase):
         self.assertEqual(client.prefixes[0].PREFIX, '20010db8000000000000000000000000')
         self.assertEqual(client.prefixes[0].LENGTH, '64')
 
-    def test_from_config_uses_fixed_client_addresses_without_class_extras(self):
+    def test_from_config_does_not_duplicate_fixed_address_from_class(self):
         fixed_address = '20010db808388f000000c0fffea80002'
         random_address = '20010db808388f000123456789abcdef'
         original_addresses = cfg.ADDRESSES
@@ -195,7 +195,7 @@ class PrefixSubstitutionTest(unittest.TestCase):
             from_config(client=client, client_config=client_config, transaction=transaction)
             self.assertEqual(
                 [(address.ADDRESS, address.IA_TYPE) for address in client.addresses],
-                [(fixed_address, 'na')],
+                [(fixed_address, 'na'), (random_address, 'ta')],
             )
         finally:
             cfg.ADDRESSES = original_addresses

--- a/tests/test_prefix_substitution.py
+++ b/tests/test_prefix_substitution.py
@@ -165,7 +165,7 @@ class PrefixSubstitutionTest(unittest.TestCase):
         self.assertEqual(client.prefixes[0].PREFIX, '20010db8000000000000000000000000')
         self.assertEqual(client.prefixes[0].LENGTH, '64')
 
-    def test_from_config_does_not_duplicate_fixed_address_from_class(self):
+    def test_from_config_uses_fixed_client_addresses_without_class_extras(self):
         fixed_address = '20010db808388f000000c0fffea80002'
         random_address = '20010db808388f000123456789abcdef'
         original_addresses = cfg.ADDRESSES
@@ -195,7 +195,7 @@ class PrefixSubstitutionTest(unittest.TestCase):
             from_config(client=client, client_config=client_config, transaction=transaction)
             self.assertEqual(
                 [(address.ADDRESS, address.IA_TYPE) for address in client.addresses],
-                [(fixed_address, 'na'), (random_address, 'ta')],
+                [(fixed_address, 'na')],
             )
         finally:
             cfg.ADDRESSES = original_addresses

--- a/tests/test_prefix_substitution.py
+++ b/tests/test_prefix_substitution.py
@@ -4,6 +4,7 @@ import os
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 
 
 # dhcpy6d parses CLI args at import time, so provide a minimal portable config first.
@@ -70,6 +71,7 @@ from dhcpy6d.threads import RouteThread
 from dhcpy6d.globals import route_queue, timer
 from dhcpy6d import route as route_module
 reuse_lease_module = importlib.import_module('dhcpy6d.client.reuse_lease')
+from_config_module = importlib.import_module('dhcpy6d.client.from_config')
 
 os.chown = _ORIGINAL_CHOWN
 sys.argv = _ORIGINAL_ARGV
@@ -162,6 +164,42 @@ class PrefixSubstitutionTest(unittest.TestCase):
         self.assertEqual(client.addresses[0].ADDRESS, '20010db8000000000000000000000001')
         self.assertEqual(client.prefixes[0].PREFIX, '20010db8000000000000000000000000')
         self.assertEqual(client.prefixes[0].LENGTH, '64')
+
+    def test_from_config_does_not_duplicate_fixed_address_from_class(self):
+        fixed_address = '20010db808388f000000c0fffea80002'
+        random_address = '20010db808388f000123456789abcdef'
+        original_addresses = cfg.ADDRESSES
+        original_parse_pattern_address = from_config_module.parse_pattern_address
+        cfg.CLASSES['default'].ADDRESSES = ['class_eui64', 'class_random']
+        cfg.ADDRESSES = {
+            'class_eui64': SimpleNamespace(
+                CATEGORY='eui64', IA_TYPE='na', PREFERRED_LIFETIME=5400,
+                VALID_LIFETIME=7200, CLASS='default', TYPE='class_eui64',
+                DNS_UPDATE=False, DNS_ZONE='', DNS_REV_ZONE='', DNS_TTL=0,
+            ),
+            'class_random': SimpleNamespace(
+                CATEGORY='random', IA_TYPE='ta', PREFERRED_LIFETIME=5400,
+                VALID_LIFETIME=7200, CLASS='default', TYPE='class_random',
+                DNS_UPDATE=False, DNS_ZONE='', DNS_REV_ZONE='', DNS_TTL=0,
+            ),
+        }
+        from_config_module.parse_pattern_address = lambda address, *_args: (
+            fixed_address if address.TYPE == 'class_eui64' else random_address
+        )
+        try:
+            client = Client()
+            transaction = MockTransaction()
+            client_config = ClientConfig(
+                hostname='paperless', client_class='default', address=fixed_address,
+            )
+            from_config(client=client, client_config=client_config, transaction=transaction)
+            self.assertEqual(
+                [(address.ADDRESS, address.IA_TYPE) for address in client.addresses],
+                [(fixed_address, 'na'), (random_address, 'ta')],
+            )
+        finally:
+            cfg.ADDRESSES = original_addresses
+            from_config_module.parse_pattern_address = original_parse_pattern_address
 
     def test_prefix_substitution_keeps_legacy_concat_when_it_fits(self):
         cfg.PREFIX = '2001:db8:10:20'

--- a/tests/test_python311_compat.py
+++ b/tests/test_python311_compat.py
@@ -49,7 +49,7 @@ os.chown = lambda *_args, **_kwargs: None
 
 import dhcpy6d
 from dhcpy6d.client import parse_pattern
-from dhcpy6d.config import Address
+from dhcpy6d.config import Address, cfg
 from dhcpy6d.options import OPTIONS
 from dhcpy6d.storage.store import Store
 
@@ -67,6 +67,12 @@ def tearDownModule():
                 os.unlink(path)
             except FileNotFoundError:
                 pass
+
+
+class ConfigurationDefaultsTest(unittest.TestCase):
+    def test_default_cleaning_interval_is_accepted_and_converted_to_int(self):
+        self.assertEqual(cfg.CLEANING_INTERVAL, 10)
+        self.assertIsInstance(cfg.CLEANING_INTERVAL, int)
 
 
 class LazyExportTest(unittest.TestCase):


### PR DESCRIPTION
## Fix ISC dhclient retries caused by duplicate IAADDR entries

Closes #68 and references #48.

@HenriWahl, the live capture confirms the old issue is finally explained: for a client with fixed addresses, `from_config()` added the fixed list and then added class-generated EUI-64 addresses again. The ADVERTISE/REPLY therefore contained duplicate IA_NA addresses, which makes ISC dhclient retransmit and ignore out-of-state ADVERTISE packets.

This change retains the configured fixed address and omits an identical class-generated address. Different class-generated addresses, including random IA_TA addresses, are still returned.

The first commit also fixes the `cleaning_interval` default validation in the target branch so the test suite can import configuration successfully.

## Tests

- Added a regression test for a fixed address that collides with a class-generated EUI-64 address; it verifies the random IA_TA remains present.
- `python3 -m unittest discover -s tests -p "test_*.py" -v` — 18 passed.