### PR TITLE
Fix renewal of fixed delegated prefixes

### DIFF
--- a/dhcpy6d/client/reuse_lease.py
+++ b/dhcpy6d/client/reuse_lease.py
@@ -254,6 +254,20 @@ def reuse_lease(client=None, client_config=None, transaction=None):
                             # continue to advertise it as valid. It will be refused later
                             # with preferred/valid lifetime 0 via transaction prefix diff.
 
+        if client_config is not None and client_config.PREFIX is not None and \
+                transaction.interface in cfg.CLASSES[client.client_class].INTERFACE:
+            active_prefixes = {decompress_prefix(prefix.PREFIX, prefix.LENGTH)
+                               for prefix in client.prefixes}
+            for prefix in client_config.PREFIX:
+                configured_prefix = decompress_prefix(prefix['address'], prefix['length'])
+                if configured_prefix not in active_prefixes:
+                    client.prefixes.append(Prefix(prefix=prefix['address'],
+                                                  length=prefix['length'],
+                                                  preferred_lifetime=cfg.PREFERRED_LIFETIME,
+                                                  valid_lifetime=cfg.VALID_LIFETIME,
+                                                  route_link_local=False))
+                    active_prefixes.add(configured_prefix)
+
         # important indent here, has to match for...prefixes-loop!
         # look for prefixes in transaction that are invalid and add them
         # to client prefixes with flag invalid and a RFC-compliant lifetime of 0

--- a/tests/test_fixed_prefix_renew.py
+++ b/tests/test_fixed_prefix_renew.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+
+volatile_db = tempfile.NamedTemporaryFile(delete=False)
+volatile_db.close()
+config = tempfile.NamedTemporaryFile("w", delete=False)
+config.write(
+    "[dhcpy6d]\ninterface = eth0\nignore_interface = yes\n"
+    "store_config = none\nstore_sqlite_volatile = {}\n".format(volatile_db.name)
+)
+config.write("cleaning_interval = 3600\n")
+config.close()
+sys.argv = [sys.argv[0], "--config", config.name]
+
+dns = types.ModuleType("dns")
+for name in ("query", "reversename", "resolver", "update", "tsigkeyring"):
+    module = types.ModuleType("dns." + name)
+    setattr(dns, name, module)
+    sys.modules["dns." + name] = module
+sys.modules["dns"] = dns
+dns.resolver.NoAnswer = type("NoAnswer", (Exception,), {})
+dns.resolver.NoNameservers = type("NoNameservers", (Exception,), {})
+dns.resolver.Resolver = type("Resolver", (), {"__init__": lambda self: None})
+
+original_chown = os.chown
+os.chown = lambda *_args, **_kwargs: None
+from dhcpy6d.client import Client
+from dhcpy6d.client.reuse_lease import reuse_lease
+from dhcpy6d.config import cfg
+os.chown = original_chown
+
+
+class TestFixedPrefixRenew(unittest.TestCase):
+    def test_restores_fixed_prefix_when_renew_contains_empty_ia_pd(self):
+        class ClientConfig:
+            CLASS = "fixed_eth0"
+            HOSTNAME = "iserv"
+            PREFIX = [{"address": "2001:db8:838:8f00::", "length": "63"}]
+
+        class Class:
+            INTERFACE = ["eth0"]
+            ANSWER = "normal"
+            ADVERTISE = ["prefixes"]
+            PREFIXES = []
+
+        class Transaction:
+            interface = "eth0"
+            ia_options = [3, 25]
+            addresses = ["20010db808388fa3000000000000000002"]
+            prefixes = []
+
+        old_classes = cfg.CLASSES
+        cfg.CLASSES = {"fixed_eth0": Class()}
+        try:
+            client = Client()
+            client.client_class = "fixed_eth0"
+            reuse_lease(client=client, client_config=ClientConfig(), transaction=Transaction())
+            self.assertEqual(
+                [(prefix.PREFIX, prefix.LENGTH) for prefix in client.prefixes],
+                [("2001:db8:838:8f00::", "63")],
+            )
+        finally:
+            cfg.CLASSES = old_classes
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- retain configured fixed delegated prefixes when a RENEW or REBIND carries IA_NA plus an empty IA_PD
- cover the empty-IA_PD exchange with a focused regression test

## Background
A fixed-prefix client temporarily loses its delegated IPv6 prefix at renewal. dhcpcd removes the delegated address and route, then immediately SOLICITs and receives the same prefix again. This creates a short but real routing outage for networks behind the delegation.

The behavior follows the condition introduced by PR #53: a RENEW/REBIND containing IA_NA enters `reuse_lease()`. That function reconstructs delegated prefixes only from `transaction.prefixes`. dhcpcd may send an empty IA_PD, so the configured fixed prefix is omitted instead of falling back to `client_config.PREFIX`.

## Captured DHCPv6 exchange

```text
REBIND request:
  IA_NA IAID:1 T1:0 T2:0
    IA_ADDR 2001:db8:abcd:100::2 pltime:5400 vltime:7200
  IA_PD IAID:1 T1:0 T2:0

REBIND reply:
  IA_NA IAID:1 T1:2700 T2:4050
    IA_ADDR 2001:db8:abcd:100::2 pltime:5400 vltime:7200
  IA_PD IAID:1 T1:2700 T2:4050
  status-code NoBinding

SOLICIT one second later:
  IA_NA IAID:1 T1:0 T2:0
  IA_PD IAID:1 T1:0 T2:0

SOLICIT reply:
  IA_NA IAID:1 T1:2700 T2:4050
  IA_PD IAID:1 T1:2700 T2:4050
    IA_PD-prefix 2001:db8:1234::/56 pltime:5400 vltime:7200
```

The crucial distinction is that both client messages request IA_PD, but only the SOLICIT reply contains an IA_PREFIX. The REBIND reply has no usable prefix and carries `NoBinding`.

## Corresponding client logs

```text
wan0: REPLY6 received from fe80::1
wan0: 2001:db8:1234::/56: no valid lifetime
lan0: deleting address 2001:db8:1234::1/64
lan0: deleting route to 2001:db8:1234::/64
lo: deleting reject route to 2001:db8:1234::/56
wan0: DHCPv6 REPLY: No Prefix Available
wan0: delegated prefix 2001:db8:1234::/56
lan0: adding address 2001:db8:1234::1/64
lan0: adding route to 2001:db8:1234::/64
```

The `No Prefix Available` response triggers the recovery SOLICIT; normal preferred/valid lifetimes return only in that subsequent reply.

## Server logs

```text
REBIND | ia_options: [3, 25] | interface: isolated-net
REPLY  | options: [3, 7, 23, 24, 25, 39, 82, 83]
SOLICIT | ia_options: [3, 25] | interface: isolated-net | rapid_commit: True
REPLY   | options: [3, 7, 14, 23, 24, 25, 39, 82, 83] | prefixes: 2001:db8:1234::/56
```

The normal server summary includes option 25 for both replies, but it does not distinguish an empty IA_PD/status reply from an IA_PD carrying an IA_PREFIX; packet capture is needed for that distinction.

## Separate route-hook observation
The deployment also logged `RTNETLINK answers: File exists` from a route-add callback when the route already existed. That is an independent idempotency issue in the deployment helper and is deliberately not addressed by this PR; it does not explain the `NoBinding` DHCPv6 reply.

## Verification
- `python3 -m unittest tests/test_fixed_prefix_renew.py`
- `python3 -m compileall -q dhcpy6d`

The existing `tests/test_prefix_substitution.py` suite is unchanged; on this base it currently fails before test execution because `CLEANING_INTERVAL` defaults to an integer and `.isdigit()` is called on it.